### PR TITLE
添加平台抽象层和 vcpkg 依赖管理

### DIFF
--- a/include/platform/macos/macos_platform.h
+++ b/include/platform/macos/macos_platform.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "platform/platform.h"
+#include <string>
+
+namespace TemplateProject {
+namespace Platform {
+
+class MacOSPlatform : public PlatformInterface {
+public:
+    MacOSPlatform();
+    ~MacOSPlatform() override;
+    
+    bool initialize() override;
+    void cleanup() override;
+    
+    std::string getPlatformName() const override;
+    std::string getPlatformVersion() const override;
+    std::string executeCommand(const std::string& command) const override;
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> pImpl;
+};
+
+} // namespace Platform
+} // namespace TemplateProject 

--- a/include/platform/platform.h
+++ b/include/platform/platform.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+namespace TemplateProject {
+namespace Platform {
+
+/**
+ * 平台抽象层接口
+ * 用于隔离不同平台的特定实现
+ */
+class PlatformInterface {
+public:
+    virtual ~PlatformInterface() = default;
+    
+    /**
+     * 初始化平台相关资源
+     * @return 初始化是否成功
+     */
+    virtual bool initialize() = 0;
+    
+    /**
+     * 释放平台相关资源
+     */
+    virtual void cleanup() = 0;
+    
+    /**
+     * 获取平台名称
+     * @return 平台名称
+     */
+    virtual std::string getPlatformName() const = 0;
+    
+    /**
+     * 获取平台版本
+     * @return 平台版本
+     */
+    virtual std::string getPlatformVersion() const = 0;
+    
+    /**
+     * 执行平台特定命令
+     * @param command 要执行的命令
+     * @return 命令执行结果
+     */
+    virtual std::string executeCommand(const std::string& command) const = 0;
+};
+
+/**
+ * 工厂函数 - 创建当前平台的实现
+ * @return 平台实现实例
+ */
+std::unique_ptr<PlatformInterface> createPlatform();
+
+} // namespace Platform
+} // namespace TemplateProject 

--- a/include/platform/platform_detect.h
+++ b/include/platform/platform_detect.h
@@ -1,0 +1,68 @@
+#pragma once
+
+/**
+ * 平台检测宏
+ * 用于在编译时确定当前平台
+ */
+
+// 操作系统检测
+#if defined(_WIN32) || defined(_WIN64)
+    #define PLATFORM_WINDOWS 1
+#elif defined(__APPLE__) && defined(__MACH__)
+    #define PLATFORM_MACOS 1
+#elif defined(__linux__)
+    #define PLATFORM_LINUX 1
+#elif defined(__ANDROID__)
+    #define PLATFORM_ANDROID 1
+#elif defined(__FreeBSD__)
+    #define PLATFORM_FREEBSD 1
+#else
+    #define PLATFORM_UNKNOWN 1
+#endif
+
+// 编译器检测
+#if defined(_MSC_VER)
+    #define COMPILER_MSVC 1
+#elif defined(__clang__)
+    #define COMPILER_CLANG 1
+#elif defined(__GNUC__)
+    #define COMPILER_GCC 1
+#else
+    #define COMPILER_UNKNOWN 1
+#endif
+
+// 架构检测
+#if defined(_M_X64) || defined(__x86_64__)
+    #define ARCH_X64 1
+#elif defined(_M_IX86) || defined(__i386__)
+    #define ARCH_X86 1
+#elif defined(_M_ARM64) || defined(__aarch64__)
+    #define ARCH_ARM64 1
+#elif defined(_M_ARM) || defined(__arm__)
+    #define ARCH_ARM 1
+#else
+    #define ARCH_UNKNOWN 1
+#endif
+
+// 导出宏
+#if PLATFORM_WINDOWS
+    #define EXPORT_API __declspec(dllexport)
+    #define IMPORT_API __declspec(dllimport)
+#else
+    #define EXPORT_API __attribute__((visibility("default")))
+    #define IMPORT_API
+#endif
+
+// 内联宏
+#if COMPILER_MSVC
+    #define FORCE_INLINE __forceinline
+#else
+    #define FORCE_INLINE inline __attribute__((always_inline))
+#endif
+
+// 调试宏
+#if defined(DEBUG) || defined(_DEBUG)
+    #define TP_DEBUG 1
+#else
+    #define TP_DEBUG 0
+#endif 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,26 @@
 add_executable(template_project
     main.cpp
+    platform/platform_factory.cpp
 )
+
+# 添加平台特定的实现
+if(WIN32)
+    target_sources(template_project PRIVATE
+        platform/windows/windows_platform.cpp
+    )
+elseif(APPLE)
+    target_sources(template_project PRIVATE
+        platform/macos/macos_platform.cpp
+    )
+elseif(UNIX AND NOT APPLE)
+    target_sources(template_project PRIVATE
+        platform/linux/linux_platform.cpp
+    )
+else()
+    target_sources(template_project PRIVATE
+        platform/generic/generic_platform.cpp
+    )
+endif()
 
 target_include_directories(template_project
     PUBLIC

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include <fmt/core.h>
 #include <spdlog/spdlog.h>
 #include <nlohmann/json.hpp>
+#include "platform/platform.h"
 
 int main() {
     // 使用 fmt 进行格式化输出
@@ -17,6 +18,30 @@ int main() {
     };
     
     std::cout << "JSON output: " << j.dump(4) << std::endl;
+    
+    // 使用平台抽象层
+    auto platform = TemplateProject::Platform::createPlatform();
+    if (platform->initialize()) {
+        spdlog::info("Platform initialization successful");
+        
+        // 获取平台信息
+        std::string platformName = platform->getPlatformName();
+        std::string platformVersion = platform->getPlatformVersion();
+        
+        fmt::print("Running on {} version {}\n", platformName, platformVersion);
+        
+        // 执行系统命令示例
+        try {
+            std::string result = platform->executeCommand("uname -a");
+            fmt::print("Command result: {}", result);
+        } catch (const std::exception& e) {
+            spdlog::error("Failed to execute command: {}", e.what());
+        }
+        
+        platform->cleanup();
+    } else {
+        spdlog::error("Platform initialization failed");
+    }
     
     return 0;
 } 

--- a/src/platform/macos/macos_platform.cpp
+++ b/src/platform/macos/macos_platform.cpp
@@ -1,0 +1,74 @@
+#include "platform/macos/macos_platform.h"
+#include <array>
+#include <cstdio>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <sstream>
+
+#include <sys/types.h>
+#include <sys/sysctl.h>
+
+namespace TemplateProject {
+namespace Platform {
+
+class MacOSPlatform::Impl {
+public:
+    Impl() = default;
+    ~Impl() = default;
+
+    std::string getSystemVersion() const {
+        std::array<char, 128> buffer{};
+        size_t size = buffer.size();
+        
+        if (sysctlbyname("kern.osrelease", buffer.data(), &size, nullptr, 0) == 0) {
+            return std::string(buffer.data(), size);
+        }
+        
+        return "Unknown";
+    }
+    
+    std::string executeShellCommand(const std::string& command) const {
+        std::array<char, 128> buffer{};
+        std::string result;
+        
+        std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(command.c_str(), "r"), pclose);
+        if (!pipe) {
+            throw std::runtime_error("popen() failed!");
+        }
+        
+        while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
+            result += buffer.data();
+        }
+        
+        return result;
+    }
+};
+
+MacOSPlatform::MacOSPlatform() : pImpl(std::make_unique<Impl>()) {}
+
+MacOSPlatform::~MacOSPlatform() = default;
+
+bool MacOSPlatform::initialize() {
+    // 初始化 macOS 平台特定功能
+    return true;
+}
+
+void MacOSPlatform::cleanup() {
+    // 清理 macOS 平台特定资源
+}
+
+std::string MacOSPlatform::getPlatformName() const {
+    return "macOS";
+}
+
+std::string MacOSPlatform::getPlatformVersion() const {
+    return pImpl->getSystemVersion();
+}
+
+std::string MacOSPlatform::executeCommand(const std::string& command) const {
+    return pImpl->executeShellCommand(command);
+}
+
+} // namespace Platform
+} // namespace TemplateProject 

--- a/src/platform/platform_factory.cpp
+++ b/src/platform/platform_factory.cpp
@@ -1,0 +1,33 @@
+#include "platform/platform.h"
+#include "platform/platform_detect.h"
+
+#include <memory>
+#include <stdexcept>
+
+#if PLATFORM_WINDOWS
+#include "platform/windows/windows_platform.h"
+#elif PLATFORM_MACOS
+#include "platform/macos/macos_platform.h"
+#elif PLATFORM_LINUX
+#include "platform/linux/linux_platform.h"
+#else
+#include "platform/generic/generic_platform.h"
+#endif
+
+namespace TemplateProject {
+namespace Platform {
+
+std::unique_ptr<PlatformInterface> createPlatform() {
+#if PLATFORM_WINDOWS
+    return std::make_unique<WindowsPlatform>();
+#elif PLATFORM_MACOS
+    return std::make_unique<MacOSPlatform>();
+#elif PLATFORM_LINUX
+    return std::make_unique<LinuxPlatform>();
+#else
+    return std::make_unique<GenericPlatform>();
+#endif
+}
+
+} // namespace Platform
+} // namespace TemplateProject 


### PR DESCRIPTION
## 功能描述

该 PR 包含两部分主要内容：

### 1. vcpkg 依赖管理
- 添加了 `vcpkg.json` 配置文件
- 更新了 CMake 配置以支持 vcpkg
- 添加了常用依赖：
  - fmt：用于格式化输出
  - spdlog：用于日志记录
  - nlohmann-json：用于 JSON 处理
  - GTest：用于单元测试

### 2. 平台抽象层
- 创建了平台抽象接口 `PlatformInterface`
- 实现了平台检测机制
- 添加了 macOS 平台实现
- 提供了跨平台编译宏定义

## 测试方法

1. 使用 vcpkg 安装依赖：`vcpkg install`
2. 构建项目：`cmake .. -DCMAKE_TOOLCHAIN_FILE=[vcpkg root]/scripts/buildsystems/vcpkg.cmake`
3. 编译：`make`
4. 运行：`./bin/template_project`

## 依赖项

- CMake 3.15+
- C++17 兼容编译器
- vcpkg